### PR TITLE
New Filter + Modifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.0.2)
 project(iort_filters)
 
 
@@ -19,7 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
     iort_lib
 )
 find_package(jsoncpp REQUIRED)
-find_package(OpenCV 4.2.0 REQUIRED)
+find_package(OpenCV 3.4.5 REQUIRED)
 
 ## System dependencies are found with CMake's conventions
 find_package(Qt5 COMPONENTS Core Gui Widgets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.1)
 project(iort_filters)
+
 
 # # specify the C++ standard
 add_compile_options(-fPIC -shared)
@@ -18,7 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
     iort_lib
 )
 find_package(jsoncpp REQUIRED)
-find_package(OpenCV 3.4.5 REQUIRED)
+find_package(OpenCV 4.2.0 REQUIRED)
 
 ## System dependencies are found with CMake's conventions
 find_package(Qt5 COMPONENTS Core Gui Widgets)
@@ -50,6 +51,9 @@ set(iort_filters_HDRS
 
     inc/IoRT_Plot/IoRT_Plot.hpp
     inc/IoRT_Plot/IoRT_Plot_dialog.hpp
+
+    inc/MQTTOverlay/MQTTOverlay.hpp
+    inc/MQTTOverlay/MQTTOverlay_dialog.hpp
 )
 
 qt5_wrap_cpp(iort_filters_MOCS ${iort_filters_HDRS})
@@ -61,6 +65,9 @@ add_library(${PROJECT_NAME}
 
     src/IoRT_Plot/IoRT_Plot.cpp
     src/IoRT_Plot/IoRT_Plot_dialog.cpp
+
+    src/MQTTOverlay/MQTTOverlay.cpp
+    src/MQTTOverlay/MQTTOverlay_dialog.cpp
 
     ${iort_filters_MOCS}
 )

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # IoRT Filters
 
-`iort_filters` provides two example `insitu` extensions that use `iort_lib` to overlay IoT data onto an image stream as part of a demonstration of the IoT-Robotics Integration project. Other major components of the project are available at the links below:
+`iort_filters` provides three example `insitu` extensions that use `iort_lib` to overlay IoT data onto an image stream as part of a demonstration of the IoT-Robotics Integration project. Other major components of the project are available at the links below:
 
 1. [`iort_endpoint`](https://github.com/PaperFanz/iort_endpoint) - open source firmware for an ESP32 microcontroller to serve as an AWS IoT Core thing
 2. [`insitu`](https://github.com/PaperFanz/insitu) - open source situational awareness package with extension support

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ sudo catkin install iort_lib
 
 ## Testing
 
-You should now be able to discover the filters `IoRT_Plot` and `QRFilter` in the `Add Filter` modal dialogue in `insitu`.
+You should now be able to discover the filters `IoRT_Plot`, `QRFilter`, and `MQTTOverlay` in the `Add Filter` modal dialogue in `insitu`.

--- a/inc/IoRT_Plot/IoRT_Plot.hpp
+++ b/inc/IoRT_Plot/IoRT_Plot.hpp
@@ -39,7 +39,7 @@ public:
     }
 
 private:
-    void onInit(void);
+    void filterInit(void);
 
     void onDelete(void);
 

--- a/inc/MQTTOverlay/MQTTOverlay.hpp
+++ b/inc/MQTTOverlay/MQTTOverlay.hpp
@@ -1,0 +1,83 @@
+#ifndef iort_filters_MQTTOverlay_HPP
+    #define iort_filters_MQTTOverlay_HPP
+
+#include <pluginlib/class_list_macros.h>
+#include <insitu/filter.hpp>
+#include <iort_lib/iort.hpp>
+
+// C++ Standard includes
+#include <vector>
+#include <mutex>
+
+// ROS includes
+#include <ros/ros.h>
+#include <sensor_msgs/Image.h>
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.h>
+
+// OpenCV includes
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/core/core.hpp>
+
+namespace iort_filters {
+
+  namespace {
+  void drawtorect(cv::Mat& mat, cv::Rect target, const std::string& str,
+                    int face = cv::FONT_HERSHEY_PLAIN, int thickness = 1,
+                  cv::Scalar color = cv::Scalar(0, 0, 0, 255))
+  {
+      cv::Size rect = cv::getTextSize(str, face, 1.0, thickness, 0);
+      double scalex = (double)target.width / (double)rect.width;
+      double scaley = (double)target.height / (double)rect.height;
+      double scale = std::min(scalex, scaley);
+      int marginx =
+          scale == scalex ?
+              0 :
+              (int)((double)target.width * (scalex - scale) / scalex * 0.5);
+      int marginy =
+          scale == scaley ?
+              0 :
+              (int)((double)target.height * (scaley - scale) / scaley * 0.5);
+      cv::putText(
+          mat, str,
+          cv::Point(target.x + marginx, target.y + target.height - marginy), face,
+          scale, color, thickness, 8, false);
+  }
+  }
+
+  class MQTTOverlay : public insitu::Filter
+  {
+
+  public:
+      MQTTOverlay(void);
+
+      const cv::Mat apply (void);
+
+      bool hasSettingEditor(void)
+      {
+          return true;
+      }
+
+  private:
+      void onInit(void);
+
+      void onDelete(void);
+      
+      void onCore(Json::Value);
+
+      iort::Core core;
+
+      iort::Subscriber* iortSub;
+
+      image_transport::Subscriber imgSub;
+
+      std::string uuid;
+
+      cv_bridge::CvImageConstPtr cv_ptr;
+
+  }; // end class MQTTOverlay
+
+  } // end namespace iort_filters
+
+  #endif // end iort_filters_MQTTOverlay_HPP
+  

--- a/inc/MQTTOverlay/MQTTOverlay.hpp
+++ b/inc/MQTTOverlay/MQTTOverlay.hpp
@@ -69,11 +69,7 @@ namespace iort_filters {
 
       iort::Subscriber* iortSub;
 
-      image_transport::Subscriber imgSub;
-
       std::string uuid;
-
-      cv_bridge::CvImageConstPtr cv_ptr;
 
   }; // end class MQTTOverlay
 

--- a/inc/MQTTOverlay/MQTTOverlay.hpp
+++ b/inc/MQTTOverlay/MQTTOverlay.hpp
@@ -59,7 +59,7 @@ namespace iort_filters {
       }
 
   private:
-      void onInit(void);
+      void filterInit(void);
 
       void onDelete(void);
       

--- a/inc/MQTTOverlay/MQTTOverlay_dialog.hpp
+++ b/inc/MQTTOverlay/MQTTOverlay_dialog.hpp
@@ -1,0 +1,41 @@
+#ifndef iort_filters_MQTTOverlay_DIALOG_HPP
+#define iort_filters_MQTTOverlay_DIALOG_HPP
+
+#include <insitu/filter.hpp>
+
+namespace iort_filters
+{
+
+    class MQTTOverlayDialog : public insitu::FilterDialog
+    {
+        Q_OBJECT
+    private:
+        QPushButton *okButton;
+        QPushButton *cancelButton;
+        QLineEdit *text1;
+        QGridLayout *layout;
+        QLabel *desc1;
+        QLabel *desc2;
+        QListWidget *list;
+        QCheckBox *cb;
+        std::string uuid = "";
+        std::vector<std::string> queries;
+
+    public Q_SLOTS:
+
+        void onOK(void);
+
+    public:
+        MQTTOverlayDialog(insitu::Filter *parent_);
+
+        void updateList(void);
+
+        std::vector<std::string> getQueries()
+        {
+            return queries;
+        }
+    };
+
+} // end namespace iort_filters
+
+#endif // end iort_filters_MQTTOverlay_DIALOG_HPP

--- a/inc/QRFilter/QRFilter.hpp
+++ b/inc/QRFilter/QRFilter.hpp
@@ -24,7 +24,6 @@
 
 namespace iort_filters
 {
-
 void drawtorect(cv::Mat& mat, cv::Rect target, const std::string& str,
                 int face = cv::FONT_HERSHEY_PLAIN, int thickness = 1,
                 cv::Scalar color = cv::Scalar(0, 0, 0, 255))

--- a/inc/QRFilter/QRFilter.hpp
+++ b/inc/QRFilter/QRFilter.hpp
@@ -59,7 +59,7 @@ public:
     }
 
 private:
-    void onInit(void);
+    void filterInit(void);
 
     void onDelete(void);
 

--- a/inc/QRFilter/QRFilter_dialog.hpp
+++ b/inc/QRFilter/QRFilter_dialog.hpp
@@ -5,23 +5,34 @@
 
 namespace iort_filters
 {
-class QRFilterDialog : public insitu::FilterDialog
-{
-    Q_OBJECT
-private:
-    QPushButton* okButton;
-    QPushButton* cancelButton;
 
-    QGridLayout* layout;
+    class QRFilterDialog : public insitu::FilterDialog
+    {
+        Q_OBJECT
+    private:
+        QPushButton *okButton;
+        QPushButton *cancelButton;
+        QGridLayout *layout;
+        QLabel *desc;
+        QListWidget *list;
+        QCheckBox *cb;
+        std::vector<std::string> queries;
 
-public Q_SLOTS:
+    public Q_SLOTS:
 
-    void onOK(void);
+        void onOK(void);
 
-public:
-    QRFilterDialog(insitu::Filter* parent_);
-};
+    public:
+        QRFilterDialog(insitu::Filter *parent_);
 
-}    // end namespace iort_filters
+        void updateList(void);
 
-#endif    // end iort_filters_QRFilter_DIALOG_HPP
+        std::vector<std::string> getQueries()
+        {
+            return queries;
+        }
+    };
+
+} // end namespace iort_filters
+
+#endif // end iort_filters_QRFilter_DIALOG_HPP

--- a/package.xml
+++ b/package.xml
@@ -54,7 +54,7 @@
         <build_depend>roscpp</build_depend>
         <build_depend>insitu</build_depend>
         <build_depend>iort_lib</build_depend>
-
+        
         <build_export_depend>nodelet</build_export_depend>
         <build_export_depend>pluginlib</build_export_depend>
         <build_export_depend>roscpp</build_export_depend>

--- a/plugins.xml
+++ b/plugins.xml
@@ -5,5 +5,8 @@
 <class type="iort_filters::IoRT_Plot" base_class_type="insitu::Filter">
     <description>Plot IoRT data over time</description>
 </class>
+<class type="iort_filters::MQTTOverlay" base_class_type="insitu::Filter">
+    <description>Overlays sensor data</description>
+</class>
 </library>
         

--- a/src/IoRT_Plot/IoRT_Plot.cpp
+++ b/src/IoRT_Plot/IoRT_Plot.cpp
@@ -45,18 +45,24 @@ IoRT_Plot::IoRT_Plot(void)
     scanner.set_config(zbar::ZBAR_QRCODE, zbar::ZBAR_CFG_ENABLE, 1);
 }
 
-void IoRT_Plot::onInit(void)
+void IoRT_Plot::filterInit(void)
 {
     settingsDialog = new IoRT_PlotDialog(this);
 
-    /* initialize image subscriber (hardcoded for now) */
+    
     image_transport::ImageTransport it(getNodeHandle());
-    imgSub = it.subscribe("/camera_right/color/image_raw", 1, &IoRT_Plot::imageCB, this);
+    std::string image_topic = imageTopic();
+    if (image_topic.find("compressed", 0) == image_topic.length()-10) {
+        image_topic = image_topic.substr(0, image_topic.length()-11);
+    }
+    imgSub = it.subscribe(image_topic, 1, &IoRT_Plot::imageCB, this);
 }
 
 void IoRT_Plot::onDelete(void)
 {
     // TODO cleanup code
+    imgSub.shutdown();
+    delete iortSub;
 }
 
 void IoRT_Plot::onCore(Json::Value data)
@@ -85,7 +91,7 @@ const cv::Mat IoRT_Plot::apply (void)
         if (iortQueue.size() > 1)
         {
             // draw plot heading
-            cv::putText(ret, uuid + " valve_encoder:", cv::Point(10,20), cv::FONT_HERSHEY_PLAIN, 1.0, green);
+            cv::putText(ret, uuid + " potentiometer:", cv::Point(10,20), cv::FONT_HERSHEY_PLAIN, 1.0, green);
             
             // draw plot axis
             int x = 32;

--- a/src/MQTTOverlay/MQTTOverlay.cpp
+++ b/src/MQTTOverlay/MQTTOverlay.cpp
@@ -1,0 +1,124 @@
+#include <MQTTOverlay/MQTTOverlay.hpp>
+#include <MQTTOverlay/MQTTOverlay_dialog.hpp>
+
+#include <iort_lib/iort.hpp>
+
+// #define DEBUG
+#ifdef DEBUG
+#include <iostream>
+#endif
+
+namespace
+{
+
+  std::vector<std::string> queries;
+
+  void drawtorect(cv::Mat &mat, cv::Rect target, const std::string &str,
+                  int face = cv::FONT_HERSHEY_COMPLEX_SMALL, int thickness = 1,
+                  cv::Scalar color = cv::Scalar(0, 0, 0, 255))
+  {
+    cv::Size rect = cv::getTextSize(str, face, 1.0, thickness, 0);
+    double scalex = (double)target.width / (double)rect.width;
+    double scaley = (double)target.height / (double)rect.height;
+    double scale = std::min(scalex, scaley);
+    int marginx =
+        scale == scalex ? 0 : (int)((double)target.width * (scalex - scale) / scalex * 0.5);
+    int marginy =
+        scale == scaley ? 0 : (int)((double)target.height * (scaley - scale) / scaley * 0.5);
+    cv::putText(
+        mat, str,
+        cv::Point(target.x + marginx, target.y + target.height - marginy), face,
+        scale, color, thickness, 8, false);
+  }
+
+}
+
+namespace iort_filters
+{
+  /*
+Filter Implementation
+*/
+  MQTTOverlay::MQTTOverlay(void)
+  {
+    iortSub = nullptr;
+  }
+
+  void MQTTOverlay::onCore(Json::Value data)
+  {
+    settings["data"] = data;
+  }
+
+  void MQTTOverlay::onInit(void)
+  {
+    settingsDialog = new MQTTOverlayDialog(this);
+    setSize(QSize(160, 240));
+  }
+
+  void MQTTOverlay::onDelete(void)
+  {
+    delete iortSub;
+  }
+
+  const cv::Scalar white(255, 255, 255, 255);
+
+  const cv::Mat MQTTOverlay::apply(void)
+  {
+    int h = height();
+    int w = width();
+
+    cv::Mat ret = cv::Mat(
+        h,
+        w,
+        CV_8UC4,
+        cv::Scalar(0, 0, 0, 60));
+
+    // Get uuid from settings, if changed change it, subscribe to iortSub
+    if (settings.get("uuid_changed", false).asBool())
+    {
+      uuid = settings.get("uuid", "").asString();
+      delete iortSub;
+      iortSub = core.subscribe(uuid, &MQTTOverlay::onCore, this);
+      settings["uuid_changed"] = false;
+      settings["update_list"] = true;
+    }
+    if (uuid == "")
+    {
+      drawtorect(ret, cv::Rect(0, 0, w, h), "no uuid, edit filter", 1, 1, white);
+    }
+    else if (settings["data"] != Json::nullValue)
+    {
+      if (settings.get("update_list", false).asBool())
+      {
+        ((MQTTOverlayDialog *)settingsDialog)->updateList();
+        settings["update_list"] = false;
+      }
+
+      int n = ((MQTTOverlayDialog *)settingsDialog)->getQueries().size() + (settings["generate_bars"].asBool() ? settings["bars"].asInt() : 0);
+      int i = 0;
+      for (std::string q : ((MQTTOverlayDialog *)settingsDialog)->getQueries())
+      {
+        std::string data = q + ": " + settings["data"].get(q, 0).asString();
+        drawtorect(ret, cv::Rect(0, h / n * (i++), w, h / n), data, 1, 1, white);
+        if (settings["generate_bars"].asBool() && settings["data"].get(q, 0).isInt())
+        {
+          int64_t dataAsInt = settings["data"].get(q, 0).asInt64();
+          cv::rectangle(ret, cv::Rect(0, h / n * (i++) + (h / n / 3), (dataAsInt * w) / 4095, h / n / 3), cv::Scalar(255, 0, 0, 170), -1);
+        }
+      }
+    }
+    else
+    {
+      /* waiting for mqtt messages on topic, display detected uuid */
+      drawtorect(ret, cv::Rect(0, 0, w, h / 2), uuid, 1, 1, white);
+      drawtorect(ret, cv::Rect(0, h / 2, w, h / 2), "waiting for messages", 1, 1, white);
+    }
+
+    // TODO edit your overlay from user settings
+    // e.g. settings.get("key", defaultValue).asType()
+
+    return ret;
+  }
+
+} // end namespace iort_filters
+
+PLUGINLIB_EXPORT_CLASS(iort_filters::MQTTOverlay, insitu::Filter);

--- a/src/MQTTOverlay/MQTTOverlay.cpp
+++ b/src/MQTTOverlay/MQTTOverlay.cpp
@@ -48,7 +48,7 @@ Filter Implementation
     settings["data"] = data;
   }
 
-  void MQTTOverlay::onInit(void)
+  void MQTTOverlay::filterInit(void)
   {
     settingsDialog = new MQTTOverlayDialog(this);
     setSize(QSize(160, 240));
@@ -79,7 +79,7 @@ Filter Implementation
       delete iortSub;
       iortSub = core.subscribe(uuid, &MQTTOverlay::onCore, this);
       settings["uuid_changed"] = false;
-      settings["update_list"] = true;
+      settings["update_list"] = true; // flag to update dialog list once we receive a data object
     }
     if (uuid == "")
     {

--- a/src/MQTTOverlay/MQTTOverlay_dialog.cpp
+++ b/src/MQTTOverlay/MQTTOverlay_dialog.cpp
@@ -1,0 +1,91 @@
+#include <MQTTOverlay/MQTTOverlay_dialog.hpp>
+
+namespace iort_filters
+{
+
+    MQTTOverlayDialog::MQTTOverlayDialog(insitu::Filter *parent_)
+        : FilterDialog(parent_)
+    {
+        okButton = new QPushButton(tr("OK"));
+        okButton->setDefault(true);
+        cancelButton = new QPushButton(tr("Cancel"));
+        text1 = new QLineEdit();
+        desc1 = new QLabel(tr("Enter Device UUID: "), text1);
+        desc2 = new QLabel(tr("Data Member List"));
+        list = new QListWidget();
+        list->setSpacing(5);
+        list->setDragEnabled(true);
+        list->viewport()->setAcceptDrops(true);
+        list->setDropIndicatorShown(true);
+        list->setDragDropMode(QAbstractItemView::InternalMove);
+        cb = new QCheckBox("Generate bar view (0-4095) for integer members");
+
+        layout = new QGridLayout();
+        layout->addWidget(desc1, 0, 0);
+        layout->addWidget(text1, 0, 1);
+        layout->addWidget(desc2, 1, 0, 1, 2);
+        layout->addWidget(list, 2, 0, 1, 2);
+        layout->addWidget(cb, 3, 0, 1, 2);
+        layout->addWidget(cancelButton, 4, 0);
+        layout->addWidget(okButton, 4, 1);
+
+        setLayout(layout);
+
+        QObject::connect(okButton, SIGNAL(clicked()), SLOT(onOK()));
+        QObject::connect(cancelButton, SIGNAL(clicked()), SLOT(reject()));
+    }
+
+    void MQTTOverlayDialog::onOK(void)
+    {
+        Json::Value &settings = parent->getSettingsValue();
+        // TODO change parent settings e.g. settings["key"] = value
+        if (uuid != text1->text().toStdString())
+        {
+            uuid = text1->text().toStdString();
+            settings["uuid_changed"] = true;
+            settings["uuid"] = uuid;
+            list->clear();
+        }
+        else
+        {
+            queries.clear();
+            int bars = 0;
+            for (int i = 0; i < list->count(); i++)
+            {
+                QListWidgetItem *item = list->item(i);
+                if (item->checkState())
+                {
+                    queries.push_back(item->text().toStdString());
+                    if (settings["data"].get(item->text().toStdString(), 0).isInt())
+                    {
+                        bars++;
+                    }
+                }
+            }
+            settings["bars"] = bars;
+        }
+        settings["generate_bars"] = (bool)cb->checkState();
+        accept();
+    }
+
+    void MQTTOverlayDialog::updateList(void)
+    {
+        Json::Value &settings = parent->getSettingsValue();
+        std::vector<std::string> members = settings["data"].getMemberNames();
+        int bars = 0;
+        for (int i = 0; i < members.size(); i++)
+        {
+            queries.push_back(members[i]);
+            if (settings["data"].get(members[i], 0).isInt())
+            {
+                bars++;
+            }
+            QListWidgetItem *item = new QListWidgetItem(members[i].c_str(), list);
+            item->setFlags(item->flags() | Qt::ItemIsUserCheckable); // set checkable flag
+            item->setCheckState(Qt::Checked);                        // AND initialize check state
+            list->addItem(item);
+        }
+        settings["bars"] = bars;
+    }
+
+} // end namespace iort_filters

--- a/src/QRFilter/QRFilter.cpp
+++ b/src/QRFilter/QRFilter.cpp
@@ -48,15 +48,15 @@ namespace iort_filters
         settings["data"] = data;
     }
 
-    void QRFilter::onInit(void)
+    void QRFilter::filterInit(void)
     {
         settingsDialog = new QRFilterDialog(this);
-
-        /* initialize image subscriber (hardcoded for now) */
         image_transport::ImageTransport it(getNodeHandle());
-        imgSub = it.subscribe("/usb_cam/image_raw", 1, &QRFilter::imageCB, this);
-
-        //imgSub = it.subscribe("/camera_left/color/image_raw", 1, &QRFilter::imageCB, this);
+        std::string image_topic = imageTopic();
+        if (image_topic.find("compressed", 0) == image_topic.length()-10) {
+            image_topic = image_topic.substr(0, image_topic.length()-11);
+        }
+        imgSub = it.subscribe(image_topic, 1, &QRFilter::imageCB, this);
     }
 
     void QRFilter::onDelete(void)

--- a/src/QRFilter/QRFilter.cpp
+++ b/src/QRFilter/QRFilter.cpp
@@ -8,164 +8,180 @@
 #include <iostream>
 #endif
 
-namespace {
-
-void drawtorect(cv::Mat& mat, cv::Rect target, const std::string& str,
-                int face = cv::FONT_HERSHEY_PLAIN, int thickness = 1,
-                cv::Scalar color = cv::Scalar(0, 0, 0, 255))
+namespace
 {
-    cv::Size rect = cv::getTextSize(str, face, 1.0, thickness, 0);
-    double scalex = (double)target.width / (double)rect.width;
-    double scaley = (double)target.height / (double)rect.height;
-    double scale = std::min(scalex, scaley);
-    int marginx =
-        scale == scalex ?
-            0 :
-            (int)((double)target.width * (scalex - scale) / scalex * 0.5);
-    int marginy =
-        scale == scaley ?
-            0 :
-            (int)((double)target.height * (scaley - scale) / scaley * 0.5);
-    cv::putText(
-        mat, str,
-        cv::Point(target.x + marginx, target.y + target.height - marginy), face,
-        scale, color, thickness, 8, false);
-}
+
+    void drawtorect(cv::Mat &mat, cv::Rect target, const std::string &str,
+                    int face = cv::FONT_HERSHEY_PLAIN, int thickness = 1,
+                    cv::Scalar color = cv::Scalar(0, 0, 0, 255))
+    {
+        cv::Size rect = cv::getTextSize(str, face, 1.0, thickness, 0);
+        double scalex = (double)target.width / (double)rect.width;
+        double scaley = (double)target.height / (double)rect.height;
+        double scale = std::min(scalex, scaley);
+        int marginx =
+            scale == scalex ? 0 : (int)((double)target.width * (scalex - scale) / scalex * 0.5);
+        int marginy =
+            scale == scaley ? 0 : (int)((double)target.height * (scaley - scale) / scaley * 0.5);
+        cv::putText(
+            mat, str,
+            cv::Point(target.x + marginx, target.y + target.height - marginy), face,
+            scale, color, thickness, 8, false);
+    }
 
 }
 
 namespace iort_filters
 {
-/*
+
+    /*
     Filter Implementation
 */
-QRFilter::QRFilter(void)
-{
-    iortSub = nullptr;
-    scanner.set_config(zbar::ZBAR_QRCODE, zbar::ZBAR_CFG_ENABLE, 1);
-}
+    QRFilter::QRFilter(void)
+    {
+        iortSub = nullptr;
+        scanner.set_config(zbar::ZBAR_QRCODE, zbar::ZBAR_CFG_ENABLE, 1);
+    }
 
-void QRFilter::onCore(Json::Value data)
-{
-    settings["data"] = data;
-}
+    void QRFilter::onCore(Json::Value data)
+    {
+        settings["data"] = data;
+    }
 
-void QRFilter::onInit(void)
-{
-    settingsDialog = new QRFilterDialog(this);
+    void QRFilter::onInit(void)
+    {
+        settingsDialog = new QRFilterDialog(this);
 
-    /* initialize image subscriber (hardcoded for now) */
-    image_transport::ImageTransport it(getNodeHandle());
-    imgSub = it.subscribe("/camera_left/color/image_raw", 1, &QRFilter::imageCB, this);
-}
+        /* initialize image subscriber (hardcoded for now) */
+        image_transport::ImageTransport it(getNodeHandle());
+        imgSub = it.subscribe("/usb_cam/image_raw", 1, &QRFilter::imageCB, this);
 
-void QRFilter::onDelete(void)
-{
-    // TODO cleanup code
-    //delete iortSub;
-}
+        //imgSub = it.subscribe("/camera_left/color/image_raw", 1, &QRFilter::imageCB, this);
+    }
 
-const cv::Mat QRFilter::apply(void)
-{
-    /*
+    void QRFilter::onDelete(void)
+    {
+        // TODO cleanup code
+        imgSub.shutdown();
+        delete iortSub;
+    }
+
+    const cv::Scalar black(0, 0, 0, 255);
+
+    const cv::Mat QRFilter::apply(void)
+    {
+        /*
         Create a transparent image to construct your overlay on
     */
-    cv::Mat ret = cv::Mat(settings.get("height", 480).asInt(),
-                          settings.get("width", 640).asInt(), CV_8UC4,
-                          cv::Scalar(255, 255, 255, 0));
+        cv::Mat ret = cv::Mat(settings.get("height", 480).asInt(),
+                              settings.get("width", 640).asInt(), CV_8UC4,
+                              cv::Scalar(255, 255, 255, 0));
 
-    if (uuid.length() > 0)
-    {
-        /* there is a sensor currently detected in the frame */
-        cv::Mat datMat = cv::Mat(600, 600, CV_8UC4, cv::Scalar(255, 255, 255, 255));
-        std::vector<cv::Point2f> datRect = {
-            cv::Point2f(0,0),
-            cv::Point2f(0,600),
-            cv::Point2f(600,600),
-            cv::Point2f(600,0)
-        };
-
-        if (settings["data"] != Json::nullValue)
+        if (uuid.length() > 0)
         {
-            /* lambda response recieved, overlay data */
-            drawtorect(datMat, cv::Rect(0, 0, 600, 150), "valve_encoder:", 1, 8);
+            int h = 600;
+            int w = 600;
+            /* there is a sensor currently detected in the frame */
+            cv::Mat datMat = cv::Mat(600, 600, CV_8UC4, cv::Scalar(255, 255, 255, 255));
+            std::vector<cv::Point2f> datRect = {
+                cv::Point2f(0, 0),
+                cv::Point2f(0, 600),
+                cv::Point2f(600, 600),
+                cv::Point2f(600, 0)};
 
-            drawtorect(datMat, cv::Rect(0, 150, 600, 300), settings["data"].get("pot", 0).asString(), 1, 8);
+            if (settings["data"] != Json::nullValue)
+            {
+                if (settings.get("update_list", false).asBool())
+                {
+                    ((QRFilterDialog *)settingsDialog)->updateList();
+                    settings["update_list"] = false;
+                }
 
-            int64_t pot = settings["data"].get("pot", 0).asInt64();
-            cv::rectangle(datMat, cv::Rect(0, 450, (pot * 600) / 4095, 150), cv::Scalar(255, 0, 0, 255), -1);
-        }
-        else
-        {
-            /* waiting for curl to connect, display detected uuid */
-            drawtorect(datMat, cv::Rect(0, 0, 600, 600), uuid, 1, 8);
-        }
+                int n = ((QRFilterDialog *)settingsDialog)->getQueries().size() + (settings["generate_bars"].asBool() ? settings["bars"].asInt() : 0);
+                int i = 0;
+                for (std::string q : ((QRFilterDialog *)settingsDialog)->getQueries())
+                {
+                    std::string data = q + ": " + settings["data"].get(q, 0).asString();
+                    drawtorect(datMat, cv::Rect(0, h / n * (i++), w, h / n), data, 1, 8, black);
+                    if (settings["generate_bars"].asBool() && settings["data"].get(q, 0).isInt())
+                    {
+                        int64_t dataAsInt = settings["data"].get(q, 0).asInt64();
+                        cv::rectangle(datMat, cv::Rect(0, h / n * (i++) + (h / n / 3), (dataAsInt * w) / 4095, h / n / 3), cv::Scalar(255, 0, 0, 255), -1);
+                    }
+                }
+            }
+            else
+            {
+                /* waiting for mqtt messages on topic, display detected uuid */
+                drawtorect(datMat, cv::Rect(0, 0, w, h / 2), uuid, 1, 8, black);
+                drawtorect(datMat, cv::Rect(0, h / 2, w, h / 2), "waiting for messages", 1, 8, black);
+            }
 
-        /* draw bounding box */
-        qrMutex.lock();
-        cv::Mat trans = cv::findHomography(datRect, qrBBox, 0);
-        qrMutex.unlock();
-
-        cv::warpPerspective(datMat, ret, trans, ret.size());
-    }
-
-    return ret;
-}
-
-void QRFilter::imageCB(const sensor_msgs::Image::ConstPtr& msg)
-{
-    try
-    {
-        /* convert ROS image to OpenCV image */
-        cv_ptr = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::MONO8);
-
-
-#ifdef DEBUG
-        std::cout << "dims: " << cv_ptr->image.cols << "x" << cv_ptr->image.rows << "\n";
-#endif
-
-        /* convert OpenCV image to ZBar image */
-        zbar::Image zImg(cv_ptr->image.cols, cv_ptr->image.rows, "Y800",
-                         (uchar*)cv_ptr->image.data,
-                         cv_ptr->image.cols * cv_ptr->image.rows);
-
-        std::string detected_uuid;
-        if (scanner.scan(zImg) > 0)
-        {
-            /* we only care about one QR code for now */
-            auto symbol = zImg.symbol_begin();
-            detected_uuid = symbol->get_data();
-
+            /* draw bounding box */
             qrMutex.lock();
-            qrBBox.clear();
-            for (int i = 0; i < symbol->get_location_size(); ++i)
-            {
-                qrBBox.push_back(cv::Point2f(float(symbol->get_location_x(i)),
-                                             float(symbol->get_location_y(i))));
-            }
+            cv::Mat trans = cv::findHomography(datRect, qrBBox, 0);
             qrMutex.unlock();
+
+            cv::warpPerspective(datMat, ret, trans, ret.size());
         }
 
-        if (detected_uuid.length() > 0)
-        {
-            if (detected_uuid != uuid)
-            {
-                uuid = detected_uuid;
-                // if (iortSub != nullptr) delete iortSub;
-                iortSub = core.subscribe(uuid, &QRFilter::onCore, this);
-            }
-        }
-#ifdef DEBUG
-        std::cout << "detected_uuid: " << detected_uuid << "\n";
-#endif
+        return ret;
     }
-    catch (std::exception e)
+
+    void QRFilter::imageCB(const sensor_msgs::Image::ConstPtr &msg)
     {
-        qWarning("Failed to convert image: %s", e.what());
-        return;
-    }
-}
+        try
+        {
+            /* convert ROS image to OpenCV image */
+            cv_ptr = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::MONO8);
 
-}    // end namespace iort_filters
+#ifdef DEBUG
+            std::cout << "dims: " << cv_ptr->image.cols << "x" << cv_ptr->image.rows << "\n";
+#endif
+
+            /* convert OpenCV image to ZBar image */
+            zbar::Image zImg(cv_ptr->image.cols, cv_ptr->image.rows, "Y800",
+                             (uchar *)cv_ptr->image.data,
+                             cv_ptr->image.cols * cv_ptr->image.rows);
+
+            std::string detected_uuid;
+            if (scanner.scan(zImg) > 0)
+            {
+                /* we only care about one QR code for now */
+                auto symbol = zImg.symbol_begin();
+                detected_uuid = symbol->get_data();
+
+                qrMutex.lock();
+                qrBBox.clear();
+                for (int i = 0; i < symbol->get_location_size(); ++i)
+                {
+                    qrBBox.push_back(cv::Point2f(float(symbol->get_location_x(i)),
+                                                 float(symbol->get_location_y(i))));
+                }
+                qrMutex.unlock();
+            }
+
+            if (detected_uuid.length() > 0)
+            {
+                if (detected_uuid != uuid)
+                {
+                    uuid = detected_uuid;
+                    delete iortSub;
+                    settings["update_list"] = true;  // flag to update dialog list once we receive a data object
+                    iortSub = core.subscribe(uuid, &QRFilter::onCore, this);
+                }
+            }
+#ifdef DEBUG
+            std::cout << "detected_uuid: " << detected_uuid << "\n";
+#endif
+        }
+        catch (std::exception e)
+        {
+            qWarning("Failed to convert image: %s", e.what());
+            return;
+        }
+    }
+
+} // end namespace iort_filters
 
 PLUGINLIB_EXPORT_CLASS(iort_filters::QRFilter, insitu::Filter);

--- a/src/QRFilter/QRFilter_dialog.cpp
+++ b/src/QRFilter/QRFilter_dialog.cpp
@@ -48,7 +48,6 @@ namespace iort_filters
         }
         settings["bars"] = bars;
         settings["generate_bars"] = (bool)cb->checkState();
-        settings["update_list"] = true;
         accept();
     }
 
@@ -57,8 +56,6 @@ namespace iort_filters
         Json::Value &settings = parent->getSettingsValue();
         std::vector<std::string> members = settings["data"].getMemberNames();
         int bars = 0;
-        queries.clear();
-        list->clear();
         for (int i = 0; i < members.size(); i++)
         {
             queries.push_back(members[i]);

--- a/src/QRFilter/QRFilter_dialog.cpp
+++ b/src/QRFilter/QRFilter_dialog.cpp
@@ -2,28 +2,73 @@
 
 namespace iort_filters
 {
-QRFilterDialog::QRFilterDialog(insitu::Filter* parent_) : FilterDialog(parent_)
-{
-    okButton = new QPushButton(tr("OK"));
-    okButton->setDefault(true);
-    cancelButton = new QPushButton(tr("Cancel"));
+    QRFilterDialog::QRFilterDialog(insitu::Filter *parent_) : FilterDialog(parent_)
+    {
+        okButton = new QPushButton(tr("OK"));
+        okButton->setDefault(true);
+        cancelButton = new QPushButton(tr("Cancel"));
+        desc = new QLabel(tr("Data Member List"));
+        list = new QListWidget();
+        list->setSpacing(5);
+        list->setDragEnabled(true);
+        list->viewport()->setAcceptDrops(true);
+        list->setDropIndicatorShown(true);
+        list->setDragDropMode(QAbstractItemView::InternalMove);
+        cb = new QCheckBox("Generate bar view (0-4095) for integer members");
 
-    layout = new QGridLayout();
-    layout->addWidget(cancelButton, 0, 0);
-    layout->addWidget(okButton, 0, 1);
+        layout = new QGridLayout();
+        layout->addWidget(desc, 0, 0, 1, 2);
+        layout->addWidget(list, 1, 0, 1, 2);
+        layout->addWidget(cb, 2, 0, 1, 2);
+        layout->addWidget(cancelButton, 3, 0);
+        layout->addWidget(okButton, 3, 1);
 
-    setLayout(layout);
+        setLayout(layout);
 
-    QObject::connect(okButton, SIGNAL(clicked()), SLOT(onOK()));
-    QObject::connect(cancelButton, SIGNAL(clicked()), SLOT(reject()));
-}
+        QObject::connect(okButton, SIGNAL(clicked()), SLOT(onOK()));
+        QObject::connect(cancelButton, SIGNAL(clicked()), SLOT(reject()));
+    }
 
-void QRFilterDialog::onOK(void)
-{
-    Json::Value& settings = parent->getSettingsValue();
-    // TODO change parent settings e.g. settings["key"] = value
+    void QRFilterDialog::onOK(void)
+    {
+        Json::Value &settings = parent->getSettingsValue();
+        queries.clear();
+        int bars = 0;
+        for (int i = 0; i < list->count(); i++)
+        {
+            QListWidgetItem *item = list->item(i);
+            if (item->checkState())
+            {
+                queries.push_back(item->text().toStdString());
+                if (settings["data"].get(item->text().toStdString(), 0).isInt())
+                {
+                    bars++;
+                }
+            }
+        }
+        settings["bars"] = bars;
+        settings["generate_bars"] = (bool)cb->checkState();
+        accept();
+    }
 
-    accept();
-}
+    void QRFilterDialog::updateList(void)
+    {
+        Json::Value &settings = parent->getSettingsValue();
+        std::vector<std::string> members = settings["data"].getMemberNames();
+        int bars = 0;
+        for (int i = 0; i < members.size(); i++)
+        {
+            queries.push_back(members[i]);
+            if (settings["data"].get(members[i], 0).isInt())
+            {
+                bars++;
+            }
+            QListWidgetItem *item = new QListWidgetItem(members[i].c_str(), list);
+            item->setFlags(item->flags() | Qt::ItemIsUserCheckable); // set checkable flag
+            item->setCheckState(Qt::Checked);                        // AND initialize check state
+            list->addItem(item);
+        }
+        settings["bars"] = bars;
+    }
 
-}    // end namespace iort_filters
+} // end namespace iort_filters

--- a/src/QRFilter/QRFilter_dialog.cpp
+++ b/src/QRFilter/QRFilter_dialog.cpp
@@ -48,6 +48,7 @@ namespace iort_filters
         }
         settings["bars"] = bars;
         settings["generate_bars"] = (bool)cb->checkState();
+        settings["update_list"] = true;
         accept();
     }
 

--- a/src/QRFilter/QRFilter_dialog.cpp
+++ b/src/QRFilter/QRFilter_dialog.cpp
@@ -57,6 +57,8 @@ namespace iort_filters
         Json::Value &settings = parent->getSettingsValue();
         std::vector<std::string> members = settings["data"].getMemberNames();
         int bars = 0;
+        queries.clear();
+        list->clear();
         for (int i = 0; i < members.size(); i++)
         {
             queries.push_back(members[i]);

--- a/src/QRFilter/QRFilter_dialog.cpp
+++ b/src/QRFilter/QRFilter_dialog.cpp
@@ -48,7 +48,6 @@ namespace iort_filters
         }
         settings["bars"] = bars;
         settings["generate_bars"] = (bool)cb->checkState();
-        settings["update_list"] = true;
         accept();
     }
 

--- a/src/QRFilter/QRFilter_dialog.cpp
+++ b/src/QRFilter/QRFilter_dialog.cpp
@@ -57,8 +57,6 @@ namespace iort_filters
         Json::Value &settings = parent->getSettingsValue();
         std::vector<std::string> members = settings["data"].getMemberNames();
         int bars = 0;
-        queries.clear();
-        list->clear();
         for (int i = 0; i < members.size(); i++)
         {
             queries.push_back(members[i]);

--- a/src/QRFilter/QRFilter_dialog.cpp
+++ b/src/QRFilter/QRFilter_dialog.cpp
@@ -48,6 +48,7 @@ namespace iort_filters
         }
         settings["bars"] = bars;
         settings["generate_bars"] = (bool)cb->checkState();
+        settings["update_list"] = true;
         accept();
     }
 
@@ -56,6 +57,8 @@ namespace iort_filters
         Json::Value &settings = parent->getSettingsValue();
         std::vector<std::string> members = settings["data"].getMemberNames();
         int bars = 0;
+        queries.clear();
+        list->clear();
         for (int i = 0; i < members.size(); i++)
         {
             queries.push_back(members[i]);


### PR DESCRIPTION
Made some changes to existing filter + added a new filter (MQTTOverlay):

- QRFilter now has the capability to dynamically change and reorder which data members are displayed on the overlay by using the insitu edit filter option. The text will scale with the amount of data members being displayed.
![New Interface](https://user-images.githubusercontent.com/84476225/127677929-bfc9c1bb-5b98-4aa8-afb2-05dc989a4988.png)
- MQTTOverlay is a new filter that works similarly to QRFilter but allows the user to manually input the device UUID to subscribe to and overlay the data wherever they want on the screen. Makes use of the new settings feature on insitu which will allow the user to save the size and location of the overlay. Data member selection is the same as with QRFilter.